### PR TITLE
Task-7: added authorization service, basicAuthorizer & updated import service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 *.js
 *.d.ts
 node_modules
+.env
+.env.*
+*.env
 
 
 # CDK asset staging directory

--- a/authorization-service/authorization-service-stack.ts
+++ b/authorization-service/authorization-service-stack.ts
@@ -1,0 +1,51 @@
+// authorization-service/lib/authorization-service-stack.ts
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+import * as path from 'path';
+import * as dotenv from 'dotenv';
+
+// Load environment variables
+dotenv.config();
+
+export class AuthorizationServiceStack extends cdk.Stack {
+    public readonly basicAuthorizer: lambda.Function;
+    
+    constructor(scope: Construct, id: string, props?: cdk.StackProps) {
+        super(scope, id, props);
+        
+        const username = process.env.GITHUB_USERNAME;
+        const password = process.env.GITHUB_PASSWORD;
+        
+        if (!username || !password) {
+            throw new Error('GITHUB_USERNAME and GITHUB_PASSWORD must be provided in environment variables');
+        }
+        
+        // Create environment variables object
+        const environmentVars: { [key: string]: string } = {};
+        environmentVars[username] = password;
+        
+        this.basicAuthorizer = new lambda.Function(this, 'basicAuthorizerFunction', {
+            runtime: lambda.Runtime.NODEJS_18_X,
+            handler: 'basicAuthorizer.handler',
+            code: lambda.Code.fromAsset(path.join(__dirname, 'lambda')),
+            environment: {
+                [username]: password,
+            }
+        });
+        
+        // Add permissions for the Lambda to be invoked by API Gateway
+        this.basicAuthorizer.addPermission('ApiGatewayInvokePermission', {
+            principal: new iam.ServicePrincipal('apigateway.amazonaws.com'),
+            action: 'lambda:InvokeFunction'
+        });
+        
+        // Output the Lambda ARN for reference
+        new cdk.CfnOutput(this, 'BasicAuthorizerArn', {
+            value: this.basicAuthorizer.functionArn,
+            description: 'Basic Authorizer Lambda Function ARN',
+            exportName: 'BasicAuthorizerArn'
+        });
+    }
+}

--- a/authorization-service/lambda/basicAuthorizer.ts
+++ b/authorization-service/lambda/basicAuthorizer.ts
@@ -1,0 +1,61 @@
+// authorization-service/src/functions/basicAuthorizer.ts
+import { APIGatewayTokenAuthorizerEvent, APIGatewayAuthorizerResult } from 'aws-lambda';
+
+export const handler = async (event: APIGatewayTokenAuthorizerEvent): Promise<APIGatewayAuthorizerResult> => {
+    console.log('Event:', JSON.stringify(event, null, 2));
+    
+    try {
+        if (!event.authorizationToken) {
+            console.log('No authorization token provided');
+            throw new Error('Unauthorized');
+        }
+        
+        const authToken = event.authorizationToken;
+        console.log('Auth token received:', authToken);
+        
+        if (!authToken.toLowerCase().startsWith('basic ')) {
+            console.log('Token does not start with Basic');
+            throw new Error('Unauthorized');
+        }
+        
+        const base64Credentials = authToken.split(' ')[1];
+        const credentials = Buffer.from(base64Credentials, 'base64').toString('utf-8');
+        console.log('Decoded credentials:', credentials);
+        
+        const [username, password] = credentials.split(':');
+        console.log('Username:', username);
+        console.log('Password:', password);
+        console.log('Available environment variables:', Object.keys(process.env));
+        console.log('Stored password for user:', process.env[username]);
+        
+        const storedPassword = process.env[username];
+        
+        if (!storedPassword || storedPassword !== password) {
+            console.log('Password mismatch or user not found');
+            return generatePolicy('user', 'Deny', event.methodArn);
+        }
+        
+        console.log('Authentication successful');
+        return generatePolicy(username, 'Allow', event.methodArn);
+        
+    } catch (error) {
+        console.error('Error in authorizer:', error);
+        throw new Error('Unauthorized');
+    }
+};
+
+const generatePolicy = (principalId: string, effect: 'Allow' | 'Deny', resource: string) => {
+    return {
+        principalId,
+        policyDocument: {
+            Version: '2012-10-17',
+            Statement: [
+                {
+                    Action: 'execute-api:Invoke',
+                    Effect: effect,
+                    Resource: resource
+                }
+            ]
+        }
+    };
+};

--- a/bin/nodejs-aws-shop-be.ts
+++ b/bin/nodejs-aws-shop-be.ts
@@ -3,6 +3,7 @@ import 'source-map-support/register';
 import * as cdk from 'aws-cdk-lib';
 import {ProductServiceStack} from '../product-service/product-service-stack';
 import {ImportServiceStack} from '../import-service/import-service-stack';
+import {AuthorizationServiceStack} from '../authorization-service/authorization-service-stack';
 
 const app = new cdk.App();
 new ProductServiceStack(app, 'ProductServiceStack', {
@@ -12,6 +13,12 @@ new ProductServiceStack(app, 'ProductServiceStack', {
     },
 });
 new ImportServiceStack(app, 'ImportServiceStack', {
+    env: {
+        account: process.env.CDK_DEFAULT_ACCOUNT,
+        region: 'eu-central-1',
+    },
+});
+new AuthorizationServiceStack(app, 'AuthorizationServiceStack', {
     env: {
         account: process.env.CDK_DEFAULT_ACCOUNT,
         region: 'eu-central-1',

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
         "aws-cdk": "2.178.1",
         "aws-lambda": "^1.0.7",
         "aws-sdk-client-mock": "^4.1.0",
+        "dotenv": "^16.4.7",
         "esbuild": "^0.25.0",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
@@ -4707,6 +4708,19 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.4.7",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
+      "integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "aws-cdk": "2.178.1",
     "aws-lambda": "^1.0.7",
     "aws-sdk-client-mock": "^4.1.0",
+    "dotenv": "^16.4.7",
     "esbuild": "^0.25.0",
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",


### PR DESCRIPTION
**Task-7**

**Task 7.1** `Done`
Added authorization service, stack 
Created a lambda function called basicAuthorizer
Added .env file

**Task 7.2** `Done`
Added Lambda authorization to the /import path of the Import Service API Gateway.
Use your basicAuthorizer lambda as the Lambda authorizer

**Task 7.3** `Done`
Updated FE part to support auth token
PR: https://github.com/aydovnar/nodejs-aws-shop-react/pull/4

**Additional task** `Done`
Client application should display alerts for the responses in 401 and 403 HTTP statuses. This behavior should be added to the nodejs-aws-fe-main/src/index.tsx file. See PR: https://github.com/aydovnar/nodejs-aws-shop-react/pull/4

**CloudFront URL:** https://d2kdejvzt251g9.cloudfront.net/

**Expected score** - _100/100_


`.env`:
<img width="361" alt="image" src="https://github.com/user-attachments/assets/ab671917-5451-4417-a99b-b8e9b42f3364" />

`token details:`
<img width="380" alt="image" src="https://github.com/user-attachments/assets/eaa3541d-84db-4afe-bdf1-2153c0facd36" />

`request without token in the localStorage(included 401 error alert for additional task):`
<img width="1675" alt="image" src="https://github.com/user-attachments/assets/76566ec5-0d0d-456f-b28d-6a8d8c9433f4" />

`request with invalid token in the localStorage(included 403 error alert for additional task):`
<img width="1668" alt="image" src="https://github.com/user-attachments/assets/27ae7497-7980-47a6-848d-5ec39ab668e7" />

`request with valid token in the localStorage:`
<img width="1673" alt="image" src="https://github.com/user-attachments/assets/692b35ad-0d46-4619-a9f1-5cd627fc4ca9" />